### PR TITLE
update install script

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -6,14 +6,13 @@
 # Usage: sh -c "$(curl -fSs https://raw.githubusercontent.com/master-hax/pixel-backup-gang/master/install.sh)"
 ################################################################################
 
-set -eu
 pbg_tarball_version="0.0.2"
 pbg_tarball_filename="pixel-backup-gang-$pbg_tarball_version.tar.gz"
 pbg_tarball_url="https://github.com/master-hax/pixel-backup-gang/releases/download/$pbg_tarball_version/$pbg_tarball_filename"
 echo "install.sh: downloading version $pbg_tarball_version from github"
-curl -fL $pbg_tarball_url --output $pbg_tarball_filename
-echo "install.sh: unpacking the release archive (requires root)"
-su --command "tar -xvf $pbg_tarball_filename"
-echo "install.sh: make the release executable (requires root)"
-su --command "chmod +x ./pixel-backup-gang/*.sh"
+curl -fL $pbg_tarball_url --output $pbg_tarball_filename || { echo 'failed to download release archive' ; exit 1; }
+echo "install.sh: unpacking the release archive (requires root)" || { echo 'failed to unpack release archive' ; exit 1; }
+su --command "tar -xvf $pbg_tarball_filename" || { echo 'failed to inflate release archive' ; exit 1; }
+echo "install.sh: making the release executable (requires root)"
+su --command "chmod +x ./pixel-backup-gang/*.sh" || { echo 'failed to make scripts executable' ; exit 1; }
 echo "install.sh: pixel backup gang successfully installed to $(realpath ./pixel-backup-gang)"

--- a/install.sh
+++ b/install.sh
@@ -1,4 +1,4 @@
-#!/bin/sh -e
+#!/bin/sh -eu
 
 ################################################################################
 # Description: install the latest version of pixel-backup to the local directory
@@ -6,12 +6,14 @@
 # Usage: sh -c "$(curl -fSs https://raw.githubusercontent.com/master-hax/pixel-backup-gang/master/install.sh)"
 ################################################################################
 
-pbg_tarball_url="https://github.com/master-hax/pixel-backup-gang/releases/download/0.0.2/pixel-backup-gang-0.0.2.tar.gz"
-pbg_tarball_filename="pixel-backup-gang-latest.tar.gz"
-echo "install.sh: downloading the latest release"
+set -eu
+pbg_tarball_version="0.0.2"
+pbg_tarball_filename="pixel-backup-gang-$pbg_tarball_version.tar.gz"
+pbg_tarball_url="https://github.com/master-hax/pixel-backup-gang/releases/download/$pbg_tarball_version/$pbg_tarball_filename"
+echo "install.sh: downloading version $pbg_tarball_version from github"
 curl -fL $pbg_tarball_url --output $pbg_tarball_filename
 echo "install.sh: unpacking the release archive (requires root)"
-/sbin/su --command "tar -xvf $pbg_tarball_filename"
+su --command "tar -xvf $pbg_tarball_filename"
 echo "install.sh: make the release executable (requires root)"
-/sbin/su --command "chmod +x ./pixel-backup-gang/*.sh"
+su --command "chmod +x ./pixel-backup-gang/*.sh"
 echo "install.sh: pixel backup gang successfully installed to $(realpath ./pixel-backup-gang)"


### PR DESCRIPTION
* log failures and exit immediately during install
* call `su` without an explicit path for better compatibility with LineageOS (https://github.com/master-hax/pixel-backup-gang/discussions/21#discussioncomment-10954877)
* refactor variables
* update install logs

test with
```
sh -c "$(curl -fSs https://raw.githubusercontent.com/master-hax/pixel-backup-gang/install_path/install.sh)"
```