### PR TITLE
Adds support for VFAT on Android 11 and above

### DIFF
--- a/scripts/mount_ext4.sh
+++ b/scripts/mount_ext4.sh
@@ -12,7 +12,10 @@ if [ "$(readlink /proc/self/ns/mnt)" != "$(readlink /proc/1/ns/mnt)" ]; then
 fi
 
 mkdir -p -v /mnt/my_drive
-mount -t ext4 -o nosuid,nodev,noexec,noatime "$1" /mnt/my_drive
+mount \
+    -t ext4 \
+    -o nosuid,nodev,noexec,noatime \
+    "$1" /mnt/my_drive
 
 mkdir -p -v /mnt/my_drive/the_binding
 chmod -R 777 /mnt/my_drive
@@ -23,6 +26,9 @@ chown -R sdcard_rw:sdcard_rw /mnt/my_drive
 setenforce 0
 
 mkdir -p -v /mnt/runtime/write/emulated/0/the_binding
-mount -t sdcardfs -o nosuid,nodev,noexec,noatime,gid=9997 /mnt/my_drive/the_binding /mnt/runtime/write/emulated/0/the_binding
+mount \
+    -t sdcardfs \
+    -o nosuid,nodev,noexec,noatime,gid=9997 \
+    /mnt/my_drive/the_binding /mnt/runtime/write/emulated/0/the_binding
 
 # TODO: reduce permissions via chmod & sdcardfs mask

--- a/scripts/unmount.sh
+++ b/scripts/unmount.sh
@@ -21,7 +21,7 @@ else
   internal_binding_dir="/mnt/runtime/write/emulated/0/the_binding"
 fi
 
-[[ $(mount | grep -w "$internal_binding_dir") != "" ]]&& \
+[[ $(mount | grep -w "$internal_binding_dir") != "" ]] && \
   umount -v $internal_binding_dir
 
 # check if mount exists for EXT4 drives

--- a/scripts/unmount.sh
+++ b/scripts/unmount.sh
@@ -11,5 +11,19 @@ if [ "$(readlink /proc/self/ns/mnt)" != "$(readlink /proc/1/ns/mnt)" ]; then
   exit 1
 fi
 
-umount -v /mnt/runtime/write/emulated/0/the_binding
-umount -v /mnt/my_drive
+android_version=$(getprop ro.build.version.release)
+
+if [ $android_version -gt 10 ]; then
+  # for Android 11+
+  internal_binding_dir="/mnt/pass_through/0/emulated/0/the_binding"
+else
+  # for Android 10 and below
+  internal_binding_dir="/mnt/runtime/write/emulated/0/the_binding"
+fi
+
+[[ $(mount | grep -w "$internal_binding_dir") != "" ]]&& \
+  umount -v $internal_binding_dir
+
+# check if mount exists for EXT4 drives
+[[ $(mount | grep -w "/mnt/my_drive") != "" ]] && \
+  umount -v /mnt/my_drive

--- a/scripts/unmount.sh
+++ b/scripts/unmount.sh
@@ -11,19 +11,6 @@ if [ "$(readlink /proc/self/ns/mnt)" != "$(readlink /proc/1/ns/mnt)" ]; then
   exit 1
 fi
 
-android_version=$(getprop ro.build.version.release)
-
-if [ $android_version -gt 10 ]; then
-  # for Android 11+
-  internal_binding_dir="/mnt/pass_through/0/emulated/0/the_binding"
-else
-  # for Android 10 and below
-  internal_binding_dir="/mnt/runtime/write/emulated/0/the_binding"
-fi
-
-[[ $(mount | grep -w "$internal_binding_dir") != "" ]] && \
-  umount -v $internal_binding_dir
-
-# check if mount exists for EXT4 drives
-[[ $(mount | grep -w "/mnt/my_drive") != "" ]] && \
-  umount -v /mnt/my_drive
+umount -v /mnt/pass_through/0/emulated/0/the_binding
+umount -v /mnt/runtime/write/emulated/0/the_binding
+umount -v /mnt/my_drive


### PR DESCRIPTION
This has been tested on Google pixel 5a

```sh
:/ # cat /proc/filesystems
nodev	sysfs
nodev	rootfs
nodev	tmpfs
nodev	bdev
nodev	proc
nodev	cpuset
nodev	cgroup
nodev	cgroup2
nodev	configfs
nodev	tracefs
nodev	sockfs
nodev	bpf
nodev	pipefs
nodev	ramfs
nodev	devpts
	ext3
	ext2
	ext4
	vfat
nodev	ecryptfs
	fuseblk
nodev	fuse
nodev	fusectl
nodev	overlay
	f2fs
nodev	selinuxfs
nodev	binder
nodev	pstore
nodev	incremental-fs
nodev	functionfs
```

```sh
[ro.build.ab_update]: [true]
[ro.build.characteristics]: [nosdcard]
[ro.build.date]: [Thu Jun 27 19:16:45 UTC 2024]
[ro.build.date.utc]: [1719515805]
[ro.build.description]: [barbet-user 14 AP2A.240805.005 12025142 release-keys]
[ro.build.display.id]: [AP2A.240805.005]
[ro.build.expect.baseband]: [g7250-00299-240229-B-11514324]
[ro.build.expect.bootloader]: [b9-0.6-10898944]
[ro.build.fingerprint]: [google/barbet/barbet:14/AP2A.240805.005/12025142:user/release-keys]
[ro.build.flavor]: [barbet-user]
[ro.build.host]: [r-82b05a39f2cf359a-r8kh]
[ro.build.id]: [AP2A.240805.005]
[ro.build.product]: [barbet]
[ro.build.tags]: [release-keys]
[ro.build.type]: [user]
[ro.build.user]: [android-build]
[ro.build.version.all_codenames]: [REL]
[ro.build.version.base_os]: []
[ro.build.version.codename]: [REL]
[ro.build.version.incremental]: [12025142]
[ro.build.version.min_supported_target_sdk]: [28]
[ro.build.version.preview_sdk]: [0]
[ro.build.version.preview_sdk_fingerprint]: [REL]
[ro.build.version.release]: [14]
[ro.build.version.release_or_codename]: [14]
[ro.build.version.release_or_preview_display]: [14]
[ro.build.version.sdk]: [34]
[ro.build.version.security_patch]: [2024-08-05]
```